### PR TITLE
Replace original library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "replace": {
+        "pear/pear_exception": "*"
+    },
     "autoload": {
         "psr-4": {
             "PEAR\\Exception\\": "src/"


### PR DESCRIPTION
Hi,
Thanks for your work. I deed this library but I cannot replace the require into all thrid-party libraries.

This configuration allow composer to use this library in place of the original library without need to change the require in all `composer.json` files.

Thanks in advance.